### PR TITLE
[hotfix][demo.py] fix reprojection to 3D tracks

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -217,7 +217,7 @@ xyztVis[..., 2] = 1.0
 
 xyztVis = np.linalg.inv(intr[None, ...]) @ xyztVis.reshape(-1, 3, 1) # (TN) 3 1
 xyztVis = xyztVis.reshape(T, -1, 3) # T N 3
-xyztVis[..., 2] *= xyzt[..., 2]
+xyztVis *= xyzt[..., [2]]
 
 pred_tracks2d = pred_tracks[0][:, :, :2]
 S1, N1, _ = pred_tracks2d.shape


### PR DESCRIPTION
Fix the bug when reprojecting predicted tracks to 3D spaces. The correct equation of reprojecting pixel $(u, v, w)$ to camera coordinate $(X_c, Y_c, Z_c)$ should be

$$
X_c = w\cdot \frac{(u - u_0)}{f_x}
$$
$$
Y_c = w\cdot \frac{(v - v_0)}{f_y}
$$
$$
Z_c = w
$$

The original code only multiplies $w$ to the z coordinate.
